### PR TITLE
Small mistake in exercise 4.22

### DIFF
--- a/04.tex
+++ b/04.tex
@@ -441,9 +441,9 @@ for all $n\geq1$.
 \begin{exercise}
 \label{xca:class2_homomorphism}
 Let $p$ be an odd prime number and 
-$P$ $p$-group of nilpotency class $\leq2$. 
+$P$ a $p$-group of nilpotency class $\leq2$. 
 Prove that if $[y,x]^p=1$ for all $x,y\in P$, then
-$P\to [P,P]$,
+$P\to P$,
 $x\mapsto x^p$, is a group homomorphism. 
 \end{exercise}
 


### PR DESCRIPTION
It said that the map lands in $[P, P]$ which is not true. For example, if $P = C_9$, then $P$ is abelian, and hence nilpotent of class $\leq 2$, and $[P, P] = {1}$. But if $x$ is a generator, then $x^3 \neq 1$, so $x^3 \notin [P, P]$.